### PR TITLE
:bug: 병용금기 정보 조회 시 업데이트된 리스트로 조회하지 않는 버그 해결

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import SearchBar from './components/searchBar';
 import CurrentList from './components/currentList';
 import searchMediInfo from './components/apis/searchMediInfo';
@@ -20,12 +20,34 @@ const App = () => {
     await setRecoMedi(searchResult);
   };
 
+  useEffect(() => {
+    const getContarindicateResult = async () => {
+      let result = [];
+      for (let i = 0; i < currentList.length; i++) {
+        for (let j = 0; j < currentList.length; j++) {
+          if (currentList[i][0] !== currentList[j][0]) {
+            console.log(currentList[i][0], currentList[j][0]);
+            let contraindicateResult = await getContraindicate(
+              currentList[i][0],
+              currentList[j][0]
+            );
+            if (contraindicateResult.ITEM_NAME !== null) {
+              console.log(contraindicateResult);
+              result.push(contraindicateResult);
+            }
+          }
+        }
+      }
+      setContraindicate(result);
+    };
+    getContarindicateResult();
+  }, [currentList]);
+
   const deleteItem = async (e) => {
     let target = e.currentTarget.innerText.split('\n')[0];
     setCurrentList(currentList.filter((item) => item[0] !== target));
   };
 
-  //! 입력한 약의 갯수 -1 만큼의 contraindicate 결과가 출력되는 버그 => 입력한 약의 갯수만큼의 contraindicate 결과 출력 수정 필요
   const addList = async (e) => {
     let isNew = true;
     const [itemName, entpName] = e.currentTarget.innerText.split('\n');
@@ -40,18 +62,7 @@ const App = () => {
       newList = [...currentList, [itemName, entpName]];
     }
     setCurrentList(newList);
-    let result = [];
-    for (let i = 0; i < currentList.length; i++) {
-      for (let j = 0; j < currentList.length; j++) {
-        // console.log(currentList[i][0], currentList[j][0], currentList[i][0] !== currentList[j][0]);
-        if (currentList[i][0] !== currentList[j][0]) {
-          let contraindicateResult = await getContraindicate(currentList[i][0], currentList[j][0]);
-          console.log(contraindicateResult);
-          result.push(contraindicateResult);
-        }
-      }
-    }
-    setContraindicate(result);
+
     if (isNew === false) {
       alert('이미 추가한 약 이름입니다.');
     }

--- a/my-app/src/components/contraindicateList.js
+++ b/my-app/src/components/contraindicateList.js
@@ -6,7 +6,7 @@ const contraindicateList = (props) => {
     console.log(contraindicate.length);
     let contraindicateList = contraindicate.map((items) => {
       return (
-        <div key={items.ITEM_SEQ}>
+        <div key={items.ITEM_NAME + items.MIXTURE_ITEM_NAME}>
           <div>제조사</div>
           <div>{items.ENTP_NAME}</div>
           <div>품목 명</div>


### PR DESCRIPTION
useEffect를 활용해 병용금기 정보 조회시 업데이트 되기 이전의 리스트를 사용하는 버그 해결, 병용금기에 해당하지 않는약품의 경우 빈 결과가 출력되는 문제 해결